### PR TITLE
Problem: (fix #27)golangci-lint version 'v1.27' isn't supported

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: golangci/golangci-lint-action@master
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.27
+          version: v1.29
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: "env.GIT_DIFF != ''"


### PR DESCRIPTION
Solution: update golangci-lint version