### PR TITLE
Problem: tests are not executed on CI (fixes #33)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,7 @@ jobs:
       - name: build
         run: make build
         if: "env.GIT_DIFF != ''"
-# FIXME: `make test` + coverage when there are tests
+      - name: test
+        run: make test
+        if: "env.GIT_DIFF != ''"
+# FIXME: coverage when there are tests


### PR DESCRIPTION
Solution: extended the build GH action to include `make test` that runs "go test"