### PR TITLE
Problem (Fix #65): no tool to run multi-node integration tests

### DIFF
--- a/pystarport/.gitignore
+++ b/pystarport/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+/.envrc

--- a/pystarport/default.nix
+++ b/pystarport/default.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.poetry2nix.mkPoetryApplication {
+    projectDir = ./.;
+}

--- a/pystarport/poetry.lock
+++ b/pystarport/poetry.lock
@@ -1,0 +1,68 @@
+[[package]]
+category = "main"
+description = "A library for automatically generating command line interfaces."
+name = "fire"
+optional = false
+python-versions = "*"
+version = "0.3.1"
+
+[package.dependencies]
+six = "*"
+termcolor = "*"
+
+[[package]]
+category = "main"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
+
+[[package]]
+category = "main"
+description = "ANSII Color formatting for output in terminal."
+name = "termcolor"
+optional = false
+python-versions = "*"
+version = "1.1.0"
+
+[[package]]
+category = "main"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.1"
+
+[[package]]
+category = "main"
+description = "Style preserving TOML library"
+name = "tomlkit"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.0"
+
+[metadata]
+content-hash = "3b3e00227ea25e4d9392dd86b256b947ea875da4014a0356f471a381847ce698"
+lock-version = "1.1"
+python-versions = "^3.7"
+
+[metadata.files]
+fire = [
+    {file = "fire-0.3.1.tar.gz", hash = "sha256:9736a16227c3d469e5d2d296bce5b4d8fa8d7851e953bda327a455fc2994307f"},
+]
+six = [
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
+]
+toml = [
+    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
+    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+]
+tomlkit = [
+    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
+    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
+]

--- a/pystarport/pyproject.toml
+++ b/pystarport/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "pystarport"
+version = "0.1.0"
+description = "python version of cosmos starport"
+authors = ["yihuang <yi.codeplayer@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+fire = "^0.3.1"
+tomlkit = "^0.7.0"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.scripts]
+pystarport = "pystarport.cli:main"
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+

--- a/pystarport/pystarport/cli.py
+++ b/pystarport/pystarport/cli.py
@@ -1,0 +1,121 @@
+import re
+import os
+import json
+from pathlib import Path
+import asyncio
+import fire
+import tomlkit
+from .utils import execute, interact, local_ip
+from .ports import p2p_port, rpc_port, api_port, grpc_port, pprof_port
+
+CHAIN = 'chain-maind'
+CHAIN_ID = 'chainmaind'
+BASE_PORT = 26600
+
+
+async def node_id(i):
+    output = await chaind('tendermint', 'show-node-id', home=f'data/node{i}')
+    return output.decode().strip()
+
+
+async def chaind(*args, **kwargs):
+    args = list(args)
+    for k,v in kwargs.items():
+        args.append('--' + k.replace('_', '-'))
+        args.append(v)
+    return await interact(' '.join((CHAIN, *args)))
+
+
+def edit_tm_cfg(path, base_port, i, peers):
+    doc = tomlkit.parse(open(path).read())
+    doc['moniker'] = 'node%d' % i
+    # tendermint is start in process, not needed
+    # doc['proxy_app'] = 'tcp://127.0.0.1:%d' % abci_port(base_port, i)
+    doc['rpc']['laddr'] = 'tcp://0.0.0.0:%d' % rpc_port(base_port, i)
+    doc['rpc']['pprof_laddr'] = 'localhost:%d' % pprof_port(base_port, i)
+    doc['p2p']['laddr'] = 'tcp://0.0.0.0:%d' % p2p_port(base_port, i)
+    doc['p2p']['persistent_peers'] = peers
+    doc['p2p']['addr_book_strict'] = False
+    doc['p2p']['allow_duplicate_ip'] = True
+    open(path, 'w').write(tomlkit.dumps(doc))
+
+
+def edit_app_cfg(path, base_port, i):
+    doc = tomlkit.parse(open(path).read())
+    doc['api']['address'] = "tcp://0.0.0.0:%d" % api_port(base_port, i)
+    doc['grpc']['address'] = "0.0.0.0:%d" % grpc_port(base_port, i)
+    open(path, 'w').write(tomlkit.dumps(doc))
+
+
+async def init(count):
+    await interact('rm -r data', ignore_error=True)
+    for i in range(count):
+        await chaind('init', f'node{i}', chain_id=CHAIN_ID, home=f'data/node{i}')
+    await interact('mv data/node0/config/genesis.json data/')
+    await interact('mkdir data/gentx')
+    for i in range(count):
+        await interact(f'ln -sf ../../genesis.json data/node{i}/config/')
+        await interact(f'ln -sf ../../gentx data/node{i}/config/')
+
+    # create accounts
+    for i in range(count):
+        output = await chaind('keys', 'add', 'validator', home=f'data/node{i}', output='json', keyring_backend='test')
+        account = json.loads(output)
+        print('account', account)
+        await chaind('add-genesis-account', account['address'], '1cro', home=f'data/node{i}')
+        await chaind('gentx', 'validator', amount='1cro', keyring_backend='test', chain_id=CHAIN_ID, home=f'data/node{i}')
+
+    # collect-gentxs
+    await chaind('collect-gentxs', gentx_dir='data/gentx', home=f'data/node0')
+
+    # write tendermint config
+    ip = local_ip()
+    peers = ','.join(['tcp://%s@%s:%d' % (await node_id(i), ip, p2p_port(BASE_PORT, i)) for i in range(count)])
+    for i in range(count):
+        edit_tm_cfg(f'data/node{i}/config/config.toml', BASE_PORT, i, peers)
+        edit_app_cfg(f'data/node{i}/config/app.toml', BASE_PORT, i)
+
+
+async def start():
+    count = len([name for name in os.listdir('data') if re.match(r'^node\d+$', name)])
+    if count == 0:
+        print('not initialized yet', file=sys.stderr)
+        return
+    for i in range(count):
+        Path(f'data/node{i}.log').touch()
+    tasks = [execute('tail -f ' + ' '.join(f'data/node{i}.log' for i in range(count)))] + \
+        [execute(f'{CHAIN} start --home data/node{i} > data/node{i}.log') for i in range(count)]
+    await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+
+async def serve(count):
+    await execute('go install -mod readonly ./cmd/chain-maind')
+    await init(count)
+    await start()
+
+
+class CLI:
+    def init(self, count=1):
+        '''
+        initialize testnet data directory
+        '''
+        asyncio.run(init(count))
+
+    def start(self):
+        '''
+        start testnet processes
+        '''
+        asyncio.run(start())
+
+    def serve(self, count=1):
+        '''
+        build, init and start
+        '''
+        asyncio.run(serve(count))
+
+
+def main():
+    fire.Fire(CLI())
+
+if __name__ == '__main__':
+    main()

--- a/pystarport/pystarport/ports.py
+++ b/pystarport/pystarport/ports.py
@@ -1,0 +1,22 @@
+def p2p_port(base_port, i):
+    return base_port + i * 10
+
+
+def rpc_port(base_port, i):
+    return base_port + i * 10 + 1
+
+
+def abci_port(base_port, i):
+    return base_port + i * 10 + 2
+
+
+def grpc_port(base_port, i):
+    return base_port + i * 10 + 3
+
+
+def api_port(base_port, i):
+    return base_port + i * 10 + 4
+
+
+def pprof_port(base_port, i):
+    return base_port + i * 10 + 5

--- a/pystarport/pystarport/utils.py
+++ b/pystarport/pystarport/utils.py
@@ -1,0 +1,39 @@
+import socket
+import asyncio
+
+
+async def execute(cmd, ignore_error=False, **kwargs):
+    proc = await asyncio.create_subprocess_shell(cmd, **kwargs)
+    # begin = time.perf_counter()
+    retcode = await proc.wait()
+    # print('[%.02f] %s' % (time.perf_counter() - begin, cmd))
+    if not ignore_error:
+        assert retcode == 0, cmd
+
+
+async def interact(cmd, ignore_error=False, input=None, **kwargs):
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        **kwargs
+    )
+    # begin = time.perf_counter()
+    (stdout, stderr) = await proc.communicate(input=input)
+    # print('[%.02f] %s' % (time.perf_counter() - begin, cmd))
+    if not ignore_error:
+        assert proc.returncode == 0, f'{stdout.decode("utf-8")} ({cmd})'
+    return stdout
+
+
+def local_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+    except IOError:
+        addr = '127.0.0.1'
+    else:
+        addr = s.getsockname()[0]
+    finally:
+        s.close()
+    return addr


### PR DESCRIPTION
Solution:
- add pystarport cli
- prepare and run multi-nodes testnet, nodes are run in different processes

usage (provided `chain-maind` in `PATH`):
```
nix run -f pystarport/default.nix -c pystarport serve 4
```

autoreloading (similar with `starport serve`):
```
nix run nixpkgs.python3Packages.watchdog -c watchmedo auto-restart -R -d cmd -d x -d app -d pystarport nix -- run -f pystarport/default.nix -c pystarport serve
```