### PR TITLE
Problem: No re-producible way to build docker image

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,4 +14,13 @@ jobs:
     - uses: cachix/install-nix-action@v10
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v6
+      with:
+        name: crypto-com
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix-shell --run integration-tests/run.sh
+    - run: nix-build -o pystarportImage -A pystarportImage docker.nix
+    - uses: actions/upload-artifact@v2
+      with:
+        name: docker_image
+        path: ./pystarportImage

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ let
     /go.mod
     /go.sum
     /integration-tests
+    /result
   '';
 in
 buildGoPackage rec {

--- a/docker.nix
+++ b/docker.nix
@@ -1,0 +1,33 @@
+{ system ? "x86_64-linux" }:
+
+let
+  pkgs = import <nixpkgs> { inherit system; };
+
+  chaind = import ./default.nix { inherit pkgs; };
+  pystarport = import ./pystarport/default.nix { inherit pkgs; };
+
+  chaindImage =
+    pkgs.dockerTools.buildImage {
+      name = "crypto-com/chain-maind";
+      tag = chaind.version;
+
+      contents = [ chaind ];
+
+      config = {
+        Cmd = [ "${chaind}/bin/chain-maind" ];
+      };
+    };
+
+  pystarportImage =
+    pkgs.dockerTools.buildImage {
+      name = "crypto-com/chain-main-pystarport";
+      tag = pystarport.version;
+
+      contents = [ chaind pystarport ];
+
+      config = {
+        Cmd = [ "${pystarport}/bin/pystarport" ];
+      };
+    };
+
+in { inherit chaindImage pystarportImage; }


### PR DESCRIPTION
Since we are doing the test with nix, we can release binary and docker image with nix, so we are confident released version is the tested version.

> to build on mac, follow instructions in https://github.com/holidaycheck/nix-remote-builder

```
$ # build image with only chain-maind binary
$ nix-build docker.nix -A chaindImage
$ du -Lh result
 39M
$ docker load < result
$ # build image with both pystarport and chain-maind binary
$ nix-build docker.nix -A pystarportImage
$ du -Lh result
 64M
$ docker load < result
```