### PR TITLE
Problem (Fix #125): can't manage chain processes in pystarport

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,7 +26,7 @@ jobs:
     - run: nix run nixpkgs.python3Packages.flake8 -c flake8 --max-line-length 88 --extend-ignore E203 integration-tests/tests pystarport
     - run: nix run nixpkgs.python3Packages.black -c black --check --diff integration-tests/tests pystarport
     - run: nix-shell --run "isort -c --diff -rc integration-tests/tests pystarport"
-    - run: nix-shell --run "python -mpytest integration-tests/tests"
+    - run: nix-shell --run "python -mpytest -v integration-tests/tests"
     - run: nix-build -o pystarportImage -A pystarportImage docker.nix
     - uses: actions/upload-artifact@v2
       if: github.ref == 'refs/heads/master'

--- a/pystarport/poetry.lock
+++ b/pystarport/poetry.lock
@@ -113,6 +113,17 @@ version = "1.15.0"
 
 [[package]]
 category = "main"
+description = "A system for controlling process state under UNIX"
+name = "supervisor"
+optional = false
+python-versions = "*"
+version = "4.2.1"
+
+[package.extras]
+testing = ["pytest", "pytest-cov"]
+
+[[package]]
+category = "main"
 description = "ANSII Color formatting for output in terminal."
 name = "termcolor"
 optional = false
@@ -140,7 +151,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "7c9f8a2300fd1f8301caea6a4ba6070321b1d2875eba720977186dab8720895c"
+content-hash = "1e309fa1a6e849c782fe11ed5d97c254136c244b74d89089b4e4f12342ef49aa"
 lock-version = "1.1"
 python-versions = "^3.7"
 
@@ -189,6 +200,10 @@ pyyaml = [
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+supervisor = [
+    {file = "supervisor-4.2.1-py2.py3-none-any.whl", hash = "sha256:75ae1d758fd6a1cb5f878333b309e0e2cb351bd6487188e4c457cc1c8ec29904"},
+    {file = "supervisor-4.2.1.tar.gz", hash = "sha256:c479c875853e9c013d1fa73e529fd2165ff1ecaecc7e82810ba57e7362ae984d"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},

--- a/pystarport/pyproject.toml
+++ b/pystarport/pyproject.toml
@@ -12,6 +12,7 @@ jsonmerge = "^1.7.0"
 PyYAML = "^5.3.1"
 python-dateutil = "^2.8.1"
 durations = "^0.3.3"
+supervisor = "^4.2.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/pystarport/pystarport/cli.py
+++ b/pystarport/pystarport/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import signal
 from pathlib import Path
 
 import fire
@@ -32,7 +33,16 @@ class CLI:
 
     async def _start(self):
         await self._cluster.start()
-        await self._cluster.watch_logs()
+
+        # register signal to quit supervisord
+        loop = asyncio.get_event_loop()
+        for signame in ("SIGINT", "SIGTERM"):
+            loop.add_signal_handler(
+                getattr(signal, signame),
+                lambda: asyncio.ensure_future(self._cluster.terminate()),
+            )
+
+        await self._cluster.wait()
 
     def start(self):
         """
@@ -49,6 +59,11 @@ class CLI:
         init + start
         """
         asyncio.run(self._serve())
+
+    def supervisorctl(self):
+        from supervisor.supervisorctl import main
+
+        main(["-c", self._cluster.data_dir / "tasks.ini"])
 
 
 def main():

--- a/pystarport/pystarport/utils.py
+++ b/pystarport/pystarport/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import configparser
 
 
 async def interact(cmd, ignore_error=False, input=None, **kwargs):
@@ -19,3 +20,12 @@ async def interact(cmd, ignore_error=False, input=None, **kwargs):
 
 def local_ip():
     return "127.0.0.1"
+
+
+def write_ini(fp, cfg):
+    ini = configparser.ConfigParser()
+    for section, items in cfg.items():
+        ini.add_section(section)
+        sec = ini[section]
+        sec.update(items)
+    ini.write(fp)

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ in
     buildInputs = [
       chain
       pystarport
+      python3Packages.poetry
       python3Packages.pytest-asyncio
       python3Packages.pytest
       python3Packages.flake8


### PR DESCRIPTION
Solution:
- integrate supervisord into pystarport
- redirect all logs to stdout
- add command supervisorctl to pystarport cli