### PR TITLE
Problem: pystarport nodes don't enable api server

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -73,6 +73,9 @@ import (
 	chainmaintypes "github.com/crypto-com/chain-main/x/chainmain/types"
 	chaingov "github.com/crypto-com/chain-main/x/gov"
 	chainstaking "github.com/crypto-com/chain-main/x/staking"
+
+	// unnamed import of statik for swagger UI support
+	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
 )
 
 var (

--- a/pystarport/pystarport/cluster.py
+++ b/pystarport/pystarport/cluster.py
@@ -379,6 +379,10 @@ def edit_tm_cfg(path, base_port, i, peers):
 
 def edit_app_cfg(path, base_port, i):
     doc = tomlkit.parse(open(path).read())
+    # enable api server
+    doc["api"]["enable"] = True
+    doc["api"]["swagger"] = True
+    doc["api"]["enabled-unsafe-cors"] = True
     doc["api"]["address"] = "tcp://0.0.0.0:%d" % ports.api_port(base_port, i)
     doc["grpc"]["address"] = "0.0.0.0:%d" % ports.grpc_port(base_port, i)
     open(path, "w").write(tomlkit.dumps(doc))


### PR DESCRIPTION
Solution:
- enable api server, swagger, unsafe-cors

swagger address: http://127.0.0.1:26654/swagger/