### PR TITLE
Problem: (fix #140)cannot build a binary for a different OS than the …

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,19 +3,6 @@ before:
   - go mod download
 
 builds:
-  - main: ./cmd/chain-maincli
-    id: chain-maincli
-    binary: chain-maincli
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-      - windows
-    goarch:
-      - amd64
-    ldflags:
-      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=crypto-com-chain -X github.com/cosmos/cosmos-sdk/version.ServerName=chain-maind -X github.com/cosmos/cosmos-sdk/version.ClientName=chain-maincli -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
   - main: ./cmd/chain-maind
     id: "chain-maind"
     binary: chain-maind
@@ -41,7 +28,6 @@ archives:
     - goos: windows
       format: zip
   builds:
-  - chain-maincli
   - chain-maind
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
…host on the latest master

Solution: disable LEDGER related build tag when build binary for a different OS other than the host OS