### PR TITLE
Problem (fix #147): can't simply add breakpoint into testing code to debug

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -10,12 +10,41 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "slow: marks tests as slow")
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--supervisord-quiet",
+        dest="supervisord-quiet",
+        action="store_true",
+        default=False,
+        help="redirect supervisord's stdout to file",
+    )
+
+
 @pytest.fixture(scope="session")
-def cluster(worker_id):
+def cluster(worker_id, pytestconfig):
     "default cluster fixture"
     match = re.search(r"\d+", worker_id)
     worker_id = int(match[0]) if match is not None else 0
     base_port = (100 + worker_id) * 100
     yield from cluster_fixture(
-        Path(__file__).parent / "configs/default.yaml", base_port
+        Path(__file__).parent / "configs/default.yaml",
+        base_port,
+        quiet=pytestconfig.getoption("supervisord-quiet"),
     )
+
+
+@pytest.fixture(scope="session")
+def suspend_capture(pytestconfig):
+    "used for pause in testing"
+
+    class suspend_guard:
+        def __init__(self):
+            self.capmanager = pytestconfig.pluginmanager.getplugin("capturemanager")
+
+        def __enter__(self):
+            self.capmanager.suspend_global_capture(in_=True)
+
+        def __exit__(self, _1, _2, _3):
+            self.capmanager.resume_global_capture()
+
+    yield suspend_guard()

--- a/integration_tests/test_slashing.py
+++ b/integration_tests/test_slashing.py
@@ -14,9 +14,13 @@ slashing testing
 
 # use custom cluster, use an unique base port
 @pytest.fixture(scope="module")
-def cluster():
+def cluster(pytestconfig):
     "override cluster fixture for this test module"
-    yield from cluster_fixture(Path(__file__).parent / "configs/slashing.yaml", 26700)
+    yield from cluster_fixture(
+        Path(__file__).parent / "configs/slashing.yaml",
+        26700,
+        quiet=pytestconfig.getoption("supervisord-quiet"),
+    )
 
 
 @pytest.mark.slow

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -56,12 +56,13 @@ def wait_for_port(port, host="127.0.0.1", timeout=40.0):
                 ) from ex
 
 
-def cluster_fixture(config_path, base_port):
+def cluster_fixture(config_path, base_port, quiet=False):
     config = yaml.safe_load(open(config_path))
     with tempfile.TemporaryDirectory(suffix=config["chain_id"]) as tmpdir:
+        print("init cluster at", tmpdir, ", base port:", base_port)
         data = Path(tmpdir)
         cluster.init_cluster(data, config, base_port)
-        supervisord = cluster.start_cluster(data)
+        supervisord = cluster.start_cluster(data, quiet=quiet)
         # wait for first node rpc port available before start testing
         wait_for_port(rpc_port(base_port, 0))
         cli = cluster.ClusterCLI(data)

--- a/pystarport/pystarport/cluster.py
+++ b/pystarport/pystarport/cluster.py
@@ -239,10 +239,12 @@ class ClusterCLI:
         )
 
 
-def start_cluster(data_dir):
-    return subprocess.Popen(
-        [sys.executable, "-msupervisor.supervisord", "-c", data_dir / "tasks.ini"]
-    )
+def start_cluster(data_dir, quiet=False):
+    cmd = [sys.executable, "-msupervisor.supervisord", "-c", data_dir / "tasks.ini"]
+    if quiet:
+        return subprocess.Popen(cmd, stdout=(data_dir / "supervisord.log").open("w"))
+    else:
+        return subprocess.Popen(cmd)
 
 
 def init_cluster(data_dir, config, base_port, cmd=None):


### PR DESCRIPTION
Solution:
- add pytest fixture to provide control on the capture manager
- add option --supervisord-quiet to make stdout cleaner when try to
  debug

`--supervisord-quiet` directs supervisord's stdout to `data/supervisord.log`, otherwise it outputs to normal stdout.

example for debug or pause the test:
```diff
--- a/integration_tests/test_slashing.py
+++ b/integration_tests/test_slashing.py
@@ -24,7 +24,7 @@ def cluster(pytestconfig):


 @pytest.mark.slow
-def test_slashing(cluster):
+def test_slashing(cluster, suspend_capture):
     "stop node2, wait for non-live slashing"
     addr = cluster.address("validator", i=2)
     val_addr = cluster.address("validator", i=2, bech="val")
@@ -47,6 +47,11 @@ def test_slashing(cluster):
     rsp = cluster.unjail(addr, i=2)
     assert rsp["code"] == 4, "still jailed, can't be unjailed"

+    with suspend_capture:
+        import pdb; pdb.set_trace()
+
     # wait for 60s and unjail again
```

Run the test with `python -mpytest -s --supervisord-quiet integration_tests/test_slashing.py`
After it's paused, to make the testing move on, just press c and ENTER.