### PR TITLE
Problem (fix #188): nix code is not auto-formatted and checked

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 jobs:
-  lintpy:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -20,17 +20,15 @@ jobs:
       run: |
         nix-env -iA cachix -f https://cachix.org/api/v1/install
         cachix use crypto-com
-    - name: lint python
-      run: nix-shell -E "$SHELL" --run "$CMD"
+    - name: lint
+      run: nix-shell -E "$SHELL" --run "make lint-ci"
       env:
-        CMD: >
-          flake8 --show-source --count --statistics
-          --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
         SHELL: >
           with import <nixpkgs> {};
           mkShell {
             buildInputs = [
               (poetry2nix.mkPoetryEnv { projectDir = ./integration_tests; })
+              nixpkgs-fmt
             ];
           }
 

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,4 @@
-{ pkgs ? import <nixpkgs> {},
-  commit ? "",
-  ledger_zemu ? false,
-}:
+{ pkgs ? import <nixpkgs> { }, commit ? "", ledger_zemu ? false, }:
 with pkgs;
 let
   src_regexes = [
@@ -17,10 +14,11 @@ let
     "^proto/.*"
     "^test$"
     "^test/.*"
-    "^go\.mod$"
-    "^go\.sum$"
+    "^go.mod$"
+    "^go.sum$"
   ];
-in buildGoModule rec {
+in
+buildGoModule rec {
   pname = "chain-maind";
   version = "0.0.1";
   src = lib.cleanSourceWith {
@@ -28,9 +26,12 @@ in buildGoModule rec {
     src = lib.sourceByRegex ./. src_regexes;
   };
   subPackages = [ "cmd/chain-maind" ];
-  vendorSha256 = sha256:0cv2hjfd4d73bmx19rwl5zrfw0ivx7l734mnbhwk71r3iwm7mn72;
+  vendorSha256 = "sha256:0cv2hjfd4d73bmx19rwl5zrfw0ivx7l734mnbhwk71r3iwm7mn72";
   runVend = true;
-  outputs = [ "out" "instrumented" ];
+  outputs = [
+    "out"
+    "instrumented"
+  ];
   buildTags = "cgo,ledger,!test_ledger_mock,!ledger_mock," +
     (if ledger_zemu then "ledger_zemu" else "!ledger_zemu");
   buildFlags = "-tags ${buildTags}";

--- a/docker.nix
+++ b/docker.nix
@@ -1,9 +1,9 @@
 { system ? "x86_64-linux", pkgs ? import <nixpkgs> { inherit system; } }:
-
 let
   chaind = import ./. { inherit pkgs; };
   pystarport = import ./pystarport { inherit pkgs chaind; };
-in {
+in
+{
   chaindImage =
     pkgs.dockerTools.buildLayeredImage {
       name = "crypto-com/chain-maind";
@@ -15,4 +15,4 @@ in {
       name = "crypto-com/chain-main-pystarport";
       config.Entrypoint = [ "${pystarport}/bin/pystarport" ];
     };
-  }
+}

--- a/integration_tests/shell.nix
+++ b/integration_tests/shell.nix
@@ -1,14 +1,15 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 with pkgs;
 let
   chaind = import ../. { inherit pkgs; ledger_zemu = true; };
   pystarport = import ../pystarport { inherit pkgs chaind; };
   testenv = poetry2nix.mkPoetryEnv { projectDir = ./.; };
 in
-  mkShell {
-    buildInputs = [
-      chaind.instrumented
-      pystarport
-      testenv
-    ];
-  }
+mkShell {
+  buildInputs = [
+    chaind.instrumented
+    pystarport
+    testenv
+    nixpkgs-fmt
+  ];
+}

--- a/pystarport/default.nix
+++ b/pystarport/default.nix
@@ -1,5 +1,5 @@
-{ pkgs ? import <nixpkgs> {},
-  chaind ? import ../. { inherit pkgs; }
+{ pkgs ? import <nixpkgs> { }
+, chaind ? import ../. { inherit pkgs; }
 }:
 pkgs.poetry2nix.mkPoetryApplication {
   projectDir = ./.;
@@ -12,6 +12,6 @@ pkgs.poetry2nix.mkPoetryApplication {
     );
   });
   preBuild = ''
-  sed -i -e 's@CHAIN = "chain-maind"  # edit by nix-build@CHAIN = "${chaind}/bin/chain-maind"@' pystarport/cluster.py
+    sed -i -e 's@CHAIN = "chain-maind"  # edit by nix-build@CHAIN = "${chaind}/bin/chain-maind"@' pystarport/cluster.py
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 with pkgs;
 mkShell {
   inputsFrom = [
@@ -12,7 +12,7 @@ mkShell {
     python3Packages.poetry
   ];
   shellHook = ''
-  # prefer local pystarport directory for development
-  export PYTHONPATH=./pystarport:$PYTHONPATH
+    # prefer local pystarport directory for development
+    export PYTHONPATH=./pystarport:$PYTHONPATH
   '';
 }


### PR DESCRIPTION
Solution:
- add nixpkgs-fmt to lint tools collection
- unify all the lint command into `make lint`
- add a `make lint-ci` to output github action friendly error
  messages(annotations) at best effort