### PR TITLE
Problem: no higher-level contribution guidelines (fixes #386)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 # Code of Conduct
 
 ## Conduct
-### Contact: chain@crypto.com
+### Contact: chain@crypto.org
 
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,18 @@
 # Contributing
 
-Thank you for your interest in contributing to Chain! Good places to start are this document and [the official documentation](https://github.com/crypto-com/chain-docs). If you have any questions, feel free to ask on [Discord](https://discord.gg/pahqHz26q4).
+Thank you for your interest in contributing to Chain! The goal of the chain-main repository is to develop the implementation
+of Crypto.org Chain to best power its network use cases in payments, finance and digital assets.
+Good places to start are this document and [the official documentation](https://github.com/crypto-org-chain/chain-docs). If you have any questions, feel free to ask on [Discord](https://discord.gg/pahqHz26q4).
 
+All work on the code base tries to adhere to the "Development Process" described in [The Collective Code Construction Contract (C4)](https://rfc.zeromq.org/spec/42/#24-development-process).
 
 ## Code of Conduct
 
 All contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Requests involving no code changes (e.g. conventions, processes or network parameters)
+
+Requests involving no code changes (e.g. conventions, processes or network parameters) should be posted as [Github Discussions](https://github.com/crypto-org-chain/chain-main/discussions) threads to allow for early feedback before e.g. being submitted for formal network governance decisions.
 
 ## Feature requests and bug reports
 
@@ -15,6 +22,11 @@ In an issue, please describe what you did, what you expected, and what happened 
 If you think that you have identified an issue with Chain that might compromise
 its users' security, please do not open a public issue on GitHub. Instead,
 we ask you to refer to [security policy](SECURITY.md).
+
+## Consensus-breaking and large structural code changes
+
+When the issue is well understood but the solution leads to a consensus-breaking change (i.e. a need for the network-wide upgrade coordination) or large structural changes to the code base, these changes should be proposed in the form of an Architectural Decision Record
+([ADR](https://github.com/crypto-org-chain/chain-main/blob/master/docs/architecture/README.md)). The ADR will help build consensus on an overall strategy to ensure the code base maintains coherence in the larger context. If you are not comfortable with writing an ADR, you can open a less-formal issue and the maintainers will help you turn it into an ADR.
 
 ## Working on issues
 There are several ways to identify an area where you can contribute to Chain:
@@ -50,6 +62,72 @@ Once you identified an issue to work on, this is the summary of your basic steps
 * In the pull request, complete its checklist, add a clear description of the problem your changes solve, and add the following statement to confirm that your contribution is your own original work: "I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://developercertificate.org/)."
 
 * The reviewer will either accept and merge your pull request, or leave comments requesting changes via the Github PR interface (you should then make changes by pushing directly to your existing PR branch).
+
+### Changelog
+
+Every non-trivial PR must update the [CHANGELOG.md](./CHANGELOG.md).
+
+The Changelog is *not* a record of what Pull Requests were merged;
+the commit history already shows that. The Changelog is a notice to the user
+about how their expectations of the software should be modified. 
+It is part of the UX of a release and is a *critical* user facing integration point.
+The Changelog must be clean, inviting, and readable, with concise, meaningful entries. 
+Entries must be semantically meaningful to users. If a change takes multiple
+Pull Requests to complete, it should likely have only a single entry in the
+Changelog describing the net effect to the user.
+
+When writing Changelog entries, ensure they are targeting users of the software,
+not fellow developers. Developers have much more context and care about more
+things than users do. Changelogs are for users. 
+
+Changelog structure is modeled after 
+[Tendermint
+Core](https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md)
+and 
+[Hashicorp Consul](http://github.com/hashicorp/consul/tree/master/CHANGELOG.md).
+See those changelogs for examples.
+
+Changes for a given release should be split between the five sections: Security, Breaking
+Changes, Features, Improvements, Bug Fixes.
+
+Changelog entries should be formatted as follows:
+```
+- [pkg] \#xxx Some description about the change (@contributor)
+```
+Here, `pkg` is the part of the code that changed (typically a
+top-level crate, but could be <crate>/<module>), `xxx` is the pull-request number, and `contributor`
+is the author/s of the change.
+
+It's also acceptable for `xxx` to refer to the relevant issue number, but pull-request
+numbers are preferred.
+Note this means pull-requests should be opened first so the changelog can then
+be updated with the pull-request's number.
+
+Changelog entries should be ordered alphabetically according to the
+`pkg`, and numerically according to the pull-request number.
+
+Changes with multiple classifications should be doubly included (eg. a bug fix
+that is also a breaking change should be recorded under both).
+
+Breaking changes are further subdivided according to the APIs/users they impact.
+Any change that effects multiple APIs/users should be recorded multiply - for
+instance, a change to some core protocol data structure might need to be
+reflected both as breaking the core protocol but also breaking any APIs where core data structures are
+exposed.
+
+## Releases
+
+Our release process is as follows:
+
+1. The [changelog](#changelog) is updated to reflect and summarize all changes in
+   the release.
+2. If the changes contain consensus-breaking changes, a new `release/vX` (or `release/vX-testnet`) branch is created
+   with the previously agreed upgrade handler code.
+   If not, changes are cherry-picked from the trunk/master onto the existing `release/vX` (or `release/vX-testnet`) branch. (See [trunk-based development](https://trunkbaseddevelopment.com/branch-for-release/).)
+3. The target commit on the release branch is tagged with `vX.Y.Z` according to the version number of
+   the anticipated release (e.g. `v1.0.0`).
+4. The tag commit push will trigger the CI pipeline -- if the build passes, Go Releaser will publish the respective binaries.
+5. The GitHub release notes are updated according to the changelog, potentially with pointers to the relevant upgrade documentation.
 
 ### Developer Certificate of Origin
 All contributions to this project are subject to the terms of the Developer Certificate of Origin, available [here](https://developercertificate.org/) and reproduced below:

--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -1,0 +1,30 @@
+# Architecture Decision Records (ADR)
+
+This is a location to record all high-level architecture decisions in the Crypto.org Chain mplementation.
+
+You can read more about the ADR concept in this [blog post](https://product.reverb.com/documenting-architecture-decisions-the-reverb-way-a3563bb24bd0#.78xhdix6t).
+
+An ADR should provide:
+
+- Context on the relevant goals and the current state
+- Proposed changes to achieve the goals
+- Summary of pros and cons
+- References
+- Changelog
+
+Note the distinction between an ADR and a spec. The ADR provides the context, intuition, reasoning, and
+justification for a change in architecture, or for the architecture of something
+new. The spec is much more compressed and streamlined summary of everything as
+it is or should be.
+
+If recorded decisions turned out to be lacking, convene a discussion, record the new decisions here, and then modify the code to match.
+
+Note the context/background should be written in the present tense.
+
+To suggest an ADR, please make use of the [ADR template](./adr-template.md) provided.
+
+## Table of Contents
+
+| ADR \# | Description | Status |
+| ------ | ----------- | ------ |
+| [000](./adr-template.md) | N/A | N/A |

--- a/doc/architecture/adr-template.md
+++ b/doc/architecture/adr-template.md
@@ -1,0 +1,36 @@
+# ADR {ADR-NUMBER}: {TITLE}
+
+## Changelog
+* {date}: {changelog}
+
+## Context
+
+> This section contains all the context one needs to understand the current state, and why there is a problem. It should be as succinct as possible and introduce the high level idea behind the solution. 
+## Decision
+
+> This section explains all of the details of the proposed solution, including implementation details.
+It should also describe affects / corollary items that may need to be changed as a part of this.
+If the proposed change will be large, please also indicate a way to do the change to maximize ease of review.
+(e.g. the optimal split of things to do between separate PR's)
+
+## Status
+
+> A decision may be "proposed" if it hasn't been agreed upon yet, or "accepted" once it is agreed upon. If a later ADR changes or reverses a decision, it may be marked as "deprecated" or "superseded" with a reference to its replacement.
+
+{Deprecated|Proposed|Accepted}
+
+## Consequences
+
+> This section describes the consequences, after applying the decision. All consequences should be summarized here, not just the "positive" ones.
+
+### Positive
+
+### Negative
+
+### Neutral
+
+## References
+
+> Are there any relevant PR comments, issues that led up to this, or articles referenced for why we made the given design choice? If so link them here!
+
+* {reference link}


### PR DESCRIPTION
Solution: added templates for ADRs and updated the contribution guidelines
with more details
