### PR TITLE
Problem: nixpkgs version don't use go 1.16

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,9 +18,6 @@ import sources.nixpkgs {
         doCheck = false;
       };
     })
-    (_: pkgs: {
-      poetry2nix = import pkgs.sources.poetry2nix { inherit (pkgs) pkgs poetry; };
-    })
   ];
   config = { };
   inherit system;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,26 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "master",
+        "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1491bab2b1113e745f107a36c7b81f89aed8cf1c",
-        "sha256": "0b4rhk42aw1gp3p6ajcklag3kwin14bqy6v2haq914sgx2nkw8bn",
+        "rev": "fde0082ca4b830b1d9d69b4f4189322512f067d7",
+        "sha256": "05ll6c4a2xg1wglpdszjjxbri89q521hb65s16i84qn6igzi316c",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/1491bab2b1113e745f107a36c7b81f89aed8cf1c.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "poetry2nix": {
-        "branch": "master",
-        "description": "Convert poetry projects to nix automagically [maintainer=@adisbladis] ",
-        "homepage": "",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "f0cc43e09f6adbbde8c1207d511cd124cdca28f4",
-        "sha256": "020qpwprkb52gimvmipixc7zqqmaxagxw9ddr75yf762s312byi3",
-        "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/f0cc43e09f6adbbde8c1207d511cd124cdca28f4.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fde0082ca4b830b1d9d69b4f4189322512f067d7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "relayer": {


### PR DESCRIPTION
Solution:
- upgrade nixpkgs to recent unstable version
- use builtin poetry2nix in nixpkgs

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

