### PR TITLE
Problem: too long default timeout_commit value

### DIFF
--- a/cmd/chain-maind/app/app.go
+++ b/cmd/chain-maind/app/app.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/imdario/mergo"
 	"github.com/spf13/cast"
@@ -75,6 +76,10 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	authclient.Codec = encodingConfig.Marshaler
 
 	initCmd := genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome)
+	initCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		serverCtx := server.GetServerContextFromCmd(cmd)
+		serverCtx.Config.Consensus.TimeoutCommit = 3 * time.Second
+	}
 	initCmd.PostRunE = func(cmd *cobra.Command, args []string) error {
 		genesisPatch := map[string]interface{}{
 			"app_state": map[string]interface{}{


### PR DESCRIPTION
Solution: changed default timeout_commit value to 3 seconds. Fixes #486.

These are the new defaults:

```
# How long we wait for a proposal block before prevoting nil
timeout_propose = "3s"
# How much timeout_propose increases with each round
timeout_propose_delta = "500ms"
# How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
timeout_prevote = "1s"
# How much the timeout_prevote increases with each round
timeout_prevote_delta = "500ms"
# How long we wait after receiving +2/3 precommits for “anything” (ie. not a single block or nil)
timeout_precommit = "1s"
# How much the timeout_precommit increases with each round
timeout_precommit_delta = "500ms"
# How long we wait after committing a block, before starting on the new
# height (this gives us a chance to receive some more precommits, even
# though we already have +2/3).
timeout_commit = "3s"
```