### PR TITLE
Problem: DenomID in NFT module does not accept capital letters

### DIFF
--- a/x/nft/types/validation.go
+++ b/x/nft/types/validation.go
@@ -50,7 +50,7 @@ func ValidateTokenID(tokenID string) error {
 		return sdkerrors.Wrapf(ErrInvalidTokenID, "the length of nft id(%s) only accepts value [%d, %d]", tokenID, MinDenomLen, MaxDenomLen)
 	}
 	if !IsBeginWithAlpha(tokenID) || !IsAlphaNumeric(tokenID) {
-		return sdkerrors.Wrapf(ErrInvalidTokenID, "nft id(%s) only accepts lowecase alphanumeric characters, and begin with an english letter", tokenID)
+		return sdkerrors.Wrapf(ErrInvalidTokenID, "nft id(%s) only accepts lowercase alphanumeric characters, and begin with an english letter", tokenID)
 	}
 	return nil
 }

--- a/x/nft/types/validation.go
+++ b/x/nft/types/validation.go
@@ -30,7 +30,7 @@ func ValidateDenomID(denomID string) error {
 		return sdkerrors.Wrapf(ErrInvalidDenom, "the length of denom(%s) only accepts value [%d, %d]", denomID, MinDenomLen, MaxDenomLen)
 	}
 	if !IsBeginWithAlpha(denomID) || !IsAlphaNumeric(denomID) {
-		return sdkerrors.Wrapf(ErrInvalidDenom, "the denom(%s) only accepts alphanumeric characters, and begin with an english letter", denomID)
+		return sdkerrors.Wrapf(ErrInvalidDenom, "the denom(%s) only accepts lowercase alphanumeric characters, and begin with an english letter", denomID)
 	}
 	return nil
 }
@@ -50,7 +50,7 @@ func ValidateTokenID(tokenID string) error {
 		return sdkerrors.Wrapf(ErrInvalidTokenID, "the length of nft id(%s) only accepts value [%d, %d]", tokenID, MinDenomLen, MaxDenomLen)
 	}
 	if !IsBeginWithAlpha(tokenID) || !IsAlphaNumeric(tokenID) {
-		return sdkerrors.Wrapf(ErrInvalidTokenID, "nft id(%s) only accepts alphanumeric characters, and begin with an english letter", tokenID)
+		return sdkerrors.Wrapf(ErrInvalidTokenID, "nft id(%s) only accepts lowecase alphanumeric characters, and begin with an english letter", tokenID)
 	}
 	return nil
 }


### PR DESCRIPTION
Solution: Modified error message clarifying that DenomID only accepts lowecase letters. Fixes #542.