### PR TITLE
Problem: random app hash mismatch after state sync or node restart in 2.1.1 pre-release binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+*August 6, 2021*
+
+## v2.1.2
+This version is based on Cosmos SDK 0.42.9 which, among other changes, contains a fix for the non-deterministic app hash mismatch
+issues after node restarts or state sync.
+
 *July 12, 2021*
 
 ## v2.1.1

--- a/app/app.go
+++ b/app/app.go
@@ -356,6 +356,7 @@ func New(
 	// CanWithdrawInvariant invariant.
 	// NOTE: staking module is required if HistoricalEntries param > 0
 	app.mm.SetOrderBeginBlockers(
+		capabilitytypes.ModuleName,
 		upgradetypes.ModuleName, minttypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
 		evidencetypes.ModuleName, stakingtypes.ModuleName, ibchost.ModuleName,
 	)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/confluentinc/bincover v0.1.0
-	github.com/cosmos/cosmos-sdk v0.42.7
+	github.com/cosmos/cosmos-sdk v0.42.9
 	github.com/cosmos/ledger-go v0.9.2 // indirect
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosmos/cosmos-sdk v0.42.7 h1:f+ZUjao2y93I37RZ7P2d94JdcEsS7Vq64SBLcNITAVc=
-github.com/cosmos/cosmos-sdk v0.42.7/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
+github.com/cosmos/cosmos-sdk v0.42.9 h1:FvF9lkWZz22Xf9K/KEfJvj+g1nFjLpU8GGTt6xkkJPU=
+github.com/cosmos/cosmos-sdk v0.42.9/go.mod h1:SrclJP9lMXxz2fCbngxb0brsPNuZXqoQQ9VHuQ3Tpf4=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -511,12 +511,12 @@
     sha256 = "0nxbn0m7lr4dg0yrwnvlkfiyg3ndv8vdpssjx7b714nivpc6ar0y"
 
 ["github.com/cosmos/cosmos-sdk"]
-  sumVersion = "v0.42.7"
+  sumVersion = "v0.42.9"
   ["github.com/cosmos/cosmos-sdk".fetch]
     type = "git"
     url = "https://github.com/cosmos/cosmos-sdk"
-    rev = "84c33215658131d87daf3c629e909e12ed9370fa"
-    sha256 = "1pqb3m3bsmxs6j0cx4d48jnsxkx9hpki30w13q7wckz21pljwi3q"
+    rev = "ed5d1656e0aea0a9b1c2c885e8d1e1bf7563f928"
+    sha256 = "0zddyfhd1h0zfzd9b1rrljs2n3vskzvz15y727h3x606hky9zlq4"
 
 ["github.com/cosmos/go-bip39"]
   sumVersion = "v1.0.0"


### PR DESCRIPTION
Solution: upgraded SDK to v0.42.9 and added the capability module to beginblocker order,
as needed according to https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.9
