### PR TITLE
Problem: test_manual_upgrade_all occasionally fails on master (fixes #619)

### DIFF
--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -285,7 +285,7 @@ def test_manual_upgrade_all(cosmovisor_cluster):
     assert rsp["code"] != 0, rsp["raw_log"]
     assert cluster.staking_pool() == old_bonded + 2009999498
 
-    target_height = cluster.block_height() + 15
+    target_height = cluster.block_height() + 30
     print("upgrade height", target_height)
 
     plan_name = "v3.0.0"


### PR DESCRIPTION
Solution: increased the target height of the upgrade proposal.
(otherwise, it's more likely the node proposes some block before upgrade shutdown
and then failing with " CONSENSUS FAILURE!!! err="+2/3 committed an invalid block: wrong Block.Header.AppHash.  Expected ..., got ...")
