### PR TITLE
Problem: latest IBC relayer release is not tested

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -15,7 +15,7 @@ import sources.nixpkgs {
       hermes = pkgs.rustPlatform.buildRustPackage rec {
         name = "hermes";
         src = sources.ibc-rs;
-        cargoSha256 = sha256:18xqp3fdvwxxz4yj343dg13ghhx0bls07nkrp0277q57s47sw2jx;
+        cargoSha256 = sha256:1sc4m4bshnjv021ic82c3m36pakf15xr5cw0dsrcjzs8pv3nq9cd;
         cargoBuildFlags = "-p ibc-relayer-cli";
         buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
           pkgs.darwin.apple_sdk.frameworks.Security

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ibc-rs": {
-        "branch": "adi/ibc-go-1-proto",
+        "branch": "master",
         "description": "IBC modules and relayer - Formal specifications and Rust implementation",
         "homepage": "",
         "owner": "informalsystems",
         "repo": "ibc-rs",
-        "rev": "b9123478151aed717b0e7f21d27fd2a592d7eaaf",
-        "sha256": "0728cbq1bcnyglskikf978h9vpw00dahgvgk2vx6pzwc5ndgjdsd",
+        "rev": "c518e15a073a5187d64cd00d1a62b2c9360a9408",
+        "sha256": "1b3sa9slm6m8ilba9zs67v817m5niljdqxr9lzmfkk553vlr25rm",
         "type": "tarball",
-        "url": "https://github.com/informalsystems/ibc-rs/archive/b9123478151aed717b0e7f21d27fd2a592d7eaaf.tar.gz",
+        "url": "https://github.com/informalsystems/ibc-rs/archive/c518e15a073a5187d64cd00d1a62b2c9360a9408.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
Solution: bumped the hermes dependency to 0.7
in nix integration tests
