### PR TITLE
Problem: publishing pystarportImage to dockerhub fails (fixes #652)

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -45,22 +45,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.*.txt
           flags: integration_tests
-      - name: Publish docker image
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
-        run: |
-          nix-build -A pystarportImage docker.nix
-          IMAGE=$(docker load < result)
-          IMAGE=${IMAGE#Loaded image: }
-          if [[ "$GITHUB_REF" = "refs/tags/"* ]]; then
-            TAG=${GITHUB_REF#refs/tags/}
-          else
-            TAG="latest"
-          fi
-          TARGET="docker.pkg.github.com/${{ github.repository }}/chain-main-pystarport:$TAG"
-          docker tag $IMAGE $TARGET
-          docker login -u "$GITHUB_ACTOR" -p "${{ github.token }}" docker.pkg.github.com
-          docker push $TARGET
-          echo "pushed: $TARGET"
       - name: Tar debug files
         if: failure()
         run: tar cfz debug_files.tar.gz -C /tmp/pytest-of-runner .


### PR DESCRIPTION
Solution: removed the dockerhub push step, as the image
doesn't seem to be used
