### PR TITLE
Problem: `make-proto` and `nix-integration-test` checks out old version of tendermint

### DIFF
--- a/integration_tests/test_feegrant.py
+++ b/integration_tests/test_feegrant.py
@@ -164,7 +164,7 @@ def test_periodic_fee_allowance(cluster):
             fees="%s%s" % (fee_coins, BASECRO_DENOM),
             fee_account=fee_granter_address,
         )
-        wait_for_block(cluster, int(tx["height"]))
+        wait_for_block(cluster, int(tx["height"]) + 1) # wait for next block
         block_info = query_block_info(cluster, tx["height"])
         wait_for_block_time(
             cluster,

--- a/integration_tests/test_feegrant.py
+++ b/integration_tests/test_feegrant.py
@@ -164,7 +164,7 @@ def test_periodic_fee_allowance(cluster):
             fees="%s%s" % (fee_coins, BASECRO_DENOM),
             fee_account=fee_granter_address,
         )
-        wait_for_block(cluster, int(tx["height"]) + 1) # wait for next block
+        wait_for_block(cluster, int(tx["height"]) + 1)  # wait for next block
         block_info = query_block_info(cluster, tx["height"])
         wait_for_block_time(
             cluster,

--- a/pystarport/convert.sh
+++ b/pystarport/convert.sh
@@ -5,7 +5,7 @@ TENDERMINT=./tendermint
 TMP=$(whereis grpc_python_plugin)
 PLUGIN="$(cut -d' ' -f2 <<<"$TMP")"
 mkdir $OUTPUT
-git clone --branch v0.34.10 https://github.com/tendermint/tendermint.git
+git clone --branch v0.34.16 https://github.com/tendermint/tendermint.git
 # cosmos
 python -m grpc.tools.protoc --proto_path=$COSMOS/proto --proto_path=$COSMOS/third_party/proto --python_out=$OUTPUT $(find $COSMOS/proto/cosmos -iname "*.proto") --grpc_python_out=$OUTPUT  --plugin=protoc-gen-grpc_python=$PLUGIN
 # cosmos third-party


### PR DESCRIPTION
Solution: Update tendermint version in `convert.sh`