### PR TITLE
Problem: Simulation tests does not point to correct location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ifeq ($(NETWORK),testnet)
 	TEST_TAGS := "--tags=testnet"
 endif
 
-SIMAPP = github.com/crypto-org-chain/chain-main/v3/app
+SIMAPP = github.com/crypto-org-chain/chain-main/v4/app
 BINDIR ?= ~/go/bin
 
 OS := $(shell uname)


### PR DESCRIPTION
Solution: Change simulation tests app location to `chain-main/v4/app`