### PR TITLE
Problem: Cosmos SDK v0.45.1 is still not used

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ let
   lib = pkgs.lib;
   build-chain-maind = { ledger_zemu ? false, network ? "mainnet" }: pkgs.buildGoApplication rec {
     pname = "chain-maind";
-    version = "3.0.0";
+    version = "4.0.0";
     src = lib.cleanSourceWith {
       name = "src";
       src = lib.sourceByRegex ./. src_regexes;

--- a/go.mod
+++ b/go.mod
@@ -142,9 +142,6 @@ replace github.com/opencontainers/image-spec => github.com/opencontainers/image-
 
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.3
 
-// TODO: remove when ibc-go upgrades cosmos-sdk version
-replace github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.44.6
-
 // TODO: remove when cosmos sdk upgrades tendermint
 replace github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.16
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/confluentinc/bincover v0.1.0
 	github.com/cosmos/cosmos-sdk v0.45.1
-	github.com/cosmos/ibc-go/v3 v3.0.0-rc1
+	github.com/cosmos/ibc-go/v3 v3.0.0-rc2
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
 	github.com/google/renameio v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/btcutil v1.0.4 h1:n7C2ngKXo7UC9gNyMNLbzqz7Asuf+7Qv4gnX/rOdQ44=
 github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/TvgUaxbU=
-github.com/cosmos/cosmos-sdk v0.44.6 h1:QCAudiVmrts9IZ0s3QrG8qXXmzA0eiZvq2m5mf/7mjg=
-github.com/cosmos/cosmos-sdk v0.44.6/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
+github.com/cosmos/cosmos-sdk v0.45.1 h1:PY79YxPea5qlRLExRnzg8/rT1Scc8GGgRs22p7DX99Q=
+github.com/cosmos/cosmos-sdk v0.45.1/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.17.3 h1:s2N819a2olOmiauVa0WAhoIJq9EhSXE9HDBAoR9k+8Y=
 github.com/cosmos/iavl v0.17.3/go.mod h1:prJoErZFABYZGDHka1R6Oay4z9PrNeFFiMKHDAMOi4w=
-github.com/cosmos/ibc-go/v3 v3.0.0-rc1 h1:5yDwMTKrBD1WJL5p/PPMalmJEOlng0OS0uX0WfFvgcw=
-github.com/cosmos/ibc-go/v3 v3.0.0-rc1/go.mod h1:Mb+1NXiPOLd+CPFlOC6BKeAUaxXlhuWenMmRiUiSmwY=
+github.com/cosmos/ibc-go/v3 v3.0.0-rc2 h1:ttolImqsdf/KOGUSU3ok5yaf9rIMdTaaNNCwuBnHfNQ=
+github.com/cosmos/ibc-go/v3 v3.0.0-rc2/go.mod h1:Mb+1NXiPOLd+CPFlOC6BKeAUaxXlhuWenMmRiUiSmwY=
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=
 github.com/cosmos/ledger-go v0.9.2/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -847,12 +847,12 @@
     sha256 = "10x22k92ra1sdddj2pksprfhsm683sldflcnjm8nfz4rjjhjwkay"
 
 ["github.com/cosmos/cosmos-sdk"]
-  sumVersion = "v0.44.6"
+  sumVersion = "v0.45.1"
   ["github.com/cosmos/cosmos-sdk".fetch]
     type = "git"
     url = "https://github.com/cosmos/cosmos-sdk"
-    rev = "6e97bf892a0888f66d435e4071882d84eb1137ea"
-    sha256 = "1fb3q9mjgiw4k3kl8cgr1hyrdw9kd52bxg5wdlnxkikmv1fi17nb"
+    rev = "2646b474c7beb0c93d4fafd395ef345f41afc251"
+    sha256 = "1z3yvvv7zzmp4likc023xmdmf9z1fjbakbqx6xazqadc5847av5l"
 
 ["github.com/cosmos/go-bip39"]
   sumVersion = "v1.0.0"
@@ -871,12 +871,12 @@
     sha256 = "115964xzwlr8j0l8f5x0v31f5hnxhd0rh5cvgy560l0dd77i735k"
 
 ["github.com/cosmos/ibc-go/v3"]
-  sumVersion = "v3.0.0-rc1"
+  sumVersion = "v3.0.0-rc2"
   ["github.com/cosmos/ibc-go/v3".fetch]
     type = "git"
     url = "https://github.com/cosmos/ibc-go"
-    rev = "22bea13d3c8c2dba224f3c41bc1d10366e58e065"
-    sha256 = "0ig4bl2278ywgwlfcb78n4wi3pw8zk94sd78x467wyxampkj7gr4"
+    rev = "16c65c622598c33991b3049c41c6b48119644f74"
+    sha256 = "183pccr2w6ck9jibwlzdjp7igxismjgkm3mmhpq8w1fv6zskf4zq"
 
 ["github.com/cosmos/ledger-cosmos-go"]
   sumVersion = "v0.9.10-0.20200929055312-01e1d341de0f"


### PR DESCRIPTION
Solution: Remove manual version override from `go.mod` + update version to `4.0.0` in `default.nix`