### PR TITLE
Problem: RegisterInterchainAccount is not exposed in icaauth keeper

### DIFF
--- a/x/icaauth/keeper/keeper.go
+++ b/x/icaauth/keeper/keeper.go
@@ -84,6 +84,10 @@ func (k *Keeper) DoSubmitTx(ctx sdk.Context, connectionID, owner string, msgs []
 	return nil
 }
 
+func (k *Keeper) RegisterInterchainAccount(ctx sdk.Context, connectionID, owner string) error {
+	return k.icaControllerKeeper.RegisterInterchainAccount(ctx, connectionID, owner)
+}
+
 // GetInterchainAccountAddress fetches the interchain account address for given `connectionId` and `owner`
 func (k *Keeper) GetInterchainAccountAddress(ctx sdk.Context, connectionID, owner string) (string, error) {
 	portID, err := icatypes.NewControllerPortID(owner)

--- a/x/icaauth/keeper/keeper.go
+++ b/x/icaauth/keeper/keeper.go
@@ -84,6 +84,7 @@ func (k *Keeper) DoSubmitTx(ctx sdk.Context, connectionID, owner string, msgs []
 	return nil
 }
 
+// RegisterInterchainAccount registers an interchain account with the given `connectionId` and `owner` on the host chain
 func (k *Keeper) RegisterInterchainAccount(ctx sdk.Context, connectionID, owner string) error {
 	return k.icaControllerKeeper.RegisterInterchainAccount(ctx, connectionID, owner)
 }

--- a/x/icaauth/keeper/msg_server_register_account.go
+++ b/x/icaauth/keeper/msg_server_register_account.go
@@ -10,7 +10,7 @@ import (
 func (k msgServer) RegisterAccount(goCtx context.Context, msg *types.MsgRegisterAccount) (*types.MsgRegisterAccountResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if err := k.icaControllerKeeper.RegisterInterchainAccount(ctx, msg.ConnectionId, msg.Owner); err != nil {
+	if err := k.RegisterInterchainAccount(ctx, msg.ConnectionId, msg.Owner); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Solution: (Fix #736) Expose RegisterInterchainAccount method
