### PR TITLE
Problem: Audit fails because of vulnerable go-ethereum dependency

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,5 +20,7 @@ jobs:
     - name: Nancy
       uses: sonatype-nexus-community/nancy-github-action@main
       # FIXME: https://github.com/crypto-com/chain-main/issues/25 remove exclusion when viper+tendermint are upgraded
+      # FIXME(CVE-2022-23327): github.com/coinbase/rosetta-sdk-go contains a vulnerable version of go-ethereum. Remove this when it is updated in upstream.
+      #                        (https://ossindex.sonatype.org/vulnerability/de9d3742-ac18-44af-bebb-5727e3957c94?component-type=golang&component-name=github.com/ethereum/go-ethereum&utm_source=nancy-client&utm_medium=integration&utm_content=0.0.0-dev)
       with:
-        nancyCommand: sleuth --exclude-vulnerability CVE-2020-15115,CVE-2020-15136,CVE-2021-41173,CVE-2020-15114
+        nancyCommand: sleuth --exclude-vulnerability CVE-2020-15115,CVE-2020-15136,CVE-2021-41173,CVE-2020-15114,CVE-2022-23327


### PR DESCRIPTION
Solution: Temporarily add it to list of `exclude-vulnerability`.

Note: It is already updated in `cosmos-sdk` and will release in v0.46.0.