### PR TITLE
Problem: min commission is not set (fixes #843)

### DIFF
--- a/integration_tests/configs/default.yaml
+++ b/integration_tests/configs/default.yaml
@@ -2,6 +2,7 @@ chaintest:
   validators:
     - coins: 10cro
       staked: 10cro
+      commission_rate: "0.000000000000000000"
     - coins: 10cro
       staked: 10cro
     # - coins: 1cro

--- a/integration_tests/pyproject.toml
+++ b/integration_tests/pyproject.toml
@@ -19,7 +19,6 @@ pytest-github-actions-annotate-failures = "^0.1.1"
 protobuf = "3.19.4"
 PyYAML = "^5.3.1"
 python-dateutil = "^2.8.1"
-# chainlibpy use version 0.2.3 pystarport
 pystarport = { git = "https://github.com/crypto-com/pystarport.git", branch = "main" }
 chainlibpy = "^2.2.0"
 

--- a/integration_tests/test_reward.py
+++ b/integration_tests/test_reward.py
@@ -12,7 +12,7 @@ def test_reward(cluster):
     validator1_address = cluster.address("validator", i=0)
     validator2_address = cluster.address("validator", i=1)
     # starts with crocncl1
-    validator1_operator_address = cluster.address("validator", i=0, bech="val")
+    # validator1_operator_address = cluster.address("validator", i=0, bech="val")
     validator2_operator_address = cluster.address("validator", i=1, bech="val")
     signer1_old_balance = cluster.balance(signer1_address)
     amount_to_send = 2

--- a/integration_tests/test_reward.py
+++ b/integration_tests/test_reward.py
@@ -19,7 +19,9 @@ def test_reward(cluster):
     fees = 3_000_000_000
     # wait for initial reward processed, so that distribution values can be read
     wait_for_block(cluster, 2)
-    old_commission_amount = cluster.distribution_commission(validator1_operator_address)
+    old_commission_amount = (
+        0  # cluster.distribution_commission(validator1_operator_address)
+    )
     old_commission_amount2 = cluster.distribution_commission(
         validator2_operator_address,
     )
@@ -37,7 +39,9 @@ def test_reward(cluster):
     wait_for_new_blocks(cluster, 2)
     signer1_balance = cluster.balance(signer1_address)
     assert signer1_balance + fees + amount_to_send == signer1_old_balance
-    commission_amount = cluster.distribution_commission(validator1_operator_address)
+    commission_amount = (
+        0  # cluster.distribution_commission(validator1_operator_address)
+    )
     commission_amount2 = cluster.distribution_commission(validator2_operator_address)
     commission_amount_diff = (commission_amount - old_commission_amount) + (
         commission_amount2 - old_commission_amount2

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -318,6 +318,35 @@ def test_manual_upgrade_all(cosmovisor_cluster):
     assert cluster.staking_pool() == old_bonded + 2009999499
 
     target_height = cluster.block_height() + 30
+    cli = cluster.cosmos_cli()
+
+    rsp = json.loads(
+        cli.raw(
+            "query",
+            "staking",
+            "validator",
+            f"{validator1_operator_address}",
+            home=cli.data_dir,
+            node=cli.node_rpc,
+            output="json",
+        )
+    )
+    print("validator1 commission", rsp["commission"]["commission_rates"]["rate"])
+    assert rsp["commission"]["commission_rates"]["rate"] == "0.000000000000000000", rsp
+    rsp = json.loads(
+        cli.raw(
+            "query",
+            "staking",
+            "validator",
+            f"{validator2_operator_address}",
+            home=cli.data_dir,
+            node=cli.node_rpc,
+            output="json",
+        )
+    )
+    print("validator2 commission", rsp["commission"]["commission_rates"]["rate"])
+
+    assert rsp["commission"]["commission_rates"]["rate"] == "0.100000000000000000", rsp
 
     upgrade(cluster, "v4.0.0", target_height, cosmos_sdk_46=False)
 
@@ -335,6 +364,48 @@ def test_manual_upgrade_all(cosmovisor_cluster):
     )
 
     assert rsp["params"]["minTimeoutDuration"] == "3600s", rsp
+    # check min commission
+    rsp = json.loads(
+        cli.raw(
+            "query",
+            "staking",
+            "params",
+            home=cli.data_dir,
+            node=cli.node_rpc,
+            output="json",
+        )
+    )
+    print("min commission", rsp["min_commission_rate"])
+
+    assert rsp["min_commission_rate"] == "0.050000000000000000", rsp
+    rsp = json.loads(
+        cli.raw(
+            "query",
+            "staking",
+            "validator",
+            f"{validator1_operator_address}",
+            home=cli.data_dir,
+            node=cli.node_rpc,
+            output="json",
+        )
+    )
+    print("validator1 commission", rsp["commission"]["commission_rates"]["rate"])
+
+    assert rsp["commission"]["commission_rates"]["rate"] == "0.050000000000000000", rsp
+    rsp = json.loads(
+        cli.raw(
+            "query",
+            "staking",
+            "validator",
+            f"{validator2_operator_address}",
+            home=cli.data_dir,
+            node=cli.node_rpc,
+            output="json",
+        )
+    )
+    print("validator2 commission", rsp["commission"]["commission_rates"]["rate"])
+
+    assert rsp["commission"]["commission_rates"]["rate"] == "0.100000000000000000", rsp
 
 
 def test_cancel_upgrade(cluster):


### PR DESCRIPTION
Solution: added a custom upgrade handler to raise
the min commission to 5% to all validators after the upgrade is executed
