### PR TITLE
Problem: state streaming is not supported in old versions

### DIFF
--- a/cmd/chain-maind/app/app.go
+++ b/cmd/chain-maind/app/app.go
@@ -235,6 +235,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {
+	startCmd.Flags().String(app.FlagStreamers, "", "Enable streamers, only file streamer is supported right now")
 }
 
 func queryCommand() *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,6 @@ replace github.com/opencontainers/image-spec => github.com/opencontainers/image-
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.0.3
 
 // needed due to a breaking change in 0.44.6
-replace github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.44.8-patch3
+replace github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.44.8-patch4
 
 replace github.com/tendermint/tendermint => github.com/tendermint/tendermint v0.34.21

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crypto-com/ledger-cosmos-go v0.9.10-0.20200929055312-01e1d341de0f h1:pizxWsDWb07eC9jhw1oEUraFSZr3q17jvBU8CZ5Cp6s=
 github.com/crypto-com/ledger-cosmos-go v0.9.10-0.20200929055312-01e1d341de0f/go.mod h1:TJ0bt9M3eOD5V6ZCUvenKA1ODkvOcYuJDMBr9/XW1QY=
-github.com/crypto-org-chain/cosmos-sdk v0.44.8-patch3 h1:TTCj/FnjlB8c8K8IVxmFynWI+JghYZAXycJ/5Bxlifw=
-github.com/crypto-org-chain/cosmos-sdk v0.44.8-patch3/go.mod h1:+OKZMhLj+Y6LCzCDsyIvpul/xk7n9lVUn8sikLWD0Jo=
+github.com/crypto-org-chain/cosmos-sdk v0.44.8-patch4 h1:M78NpHI1gmbg4fwueCC6RX5WVtceHofUcgaIzT7QXMA=
+github.com/crypto-org-chain/cosmos-sdk v0.44.8-patch4/go.mod h1:+OKZMhLj+Y6LCzCDsyIvpul/xk7n9lVUn8sikLWD0Jo=
 github.com/crypto-org-chain/keyring v1.1.6-fixes h1:AUFSu56NY6XobY6XfRoDx6v3loiOrHK5MNUm32GEjwA=
 github.com/crypto-org-chain/keyring v1.1.6-fixes/go.mod h1:0mkLWIoZuQ7uBoospo5Q9zIpqq6rYCPJDSUdeCJvPM8=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -48,8 +48,8 @@ schema = 3
     version = "v1.0.4"
     hash = "sha256-JvcBXBdjdmnaW/nyf/tw/uaOAGn1b78yxrtl2/Rs3kA="
   [mod."github.com/cosmos/cosmos-sdk"]
-    version = "v0.44.8-patch3"
-    hash = "sha256-oz+42WzRM7rOGBQ9kzCoU+nhXg5bWlMdNv6FUhU02mU="
+    version = "v0.44.8-patch4"
+    hash = "sha256-Q921P7mVr057QeFyengMAXc5+hu/j2O75ASW/AsOB+Q="
     replaced = "github.com/crypto-org-chain/cosmos-sdk"
   [mod."github.com/cosmos/go-bip39"]
     version = "v1.0.0"


### PR DESCRIPTION
Solution: backported state streaming (+ grpc nil fix) to 0.44.x fork basic integration added based on https://github.com/crypto-org-chain/cronos/pull/717
