### PR TITLE
Problem: `query nft owner` returns error when user has NFTs transferred over IBC

### DIFF
--- a/x/nft/types/keys.go
+++ b/x/nft/types/keys.go
@@ -58,12 +58,28 @@ func SplitKeyOwner(key []byte) (address sdk.AccAddress, denomID, tokenID string,
 
 func SplitKeyDenom(key []byte) (denomID, tokenID string, err error) {
 	keys := bytes.Split(key, delimiter)
-	if len(keys) != 2 {
-		return denomID, tokenID, errors.New("wrong KeyOwner")
+
+	switch len(keys) {
+	case 2:
+		{
+			denomID = string(keys[0])
+			tokenID = string(keys[1])
+		}
+	case 3:
+		{
+			if string(keys[0]) == "ibc" {
+				denomID = "ibc/" + string(keys[1])
+				tokenID = string(keys[2])
+			} else {
+				return denomID, tokenID, errors.New("wrong KeyOwner")
+			}
+		}
+	default:
+		{
+			return denomID, tokenID, errors.New("wrong KeyOwner")
+		}
 	}
 
-	denomID = string(keys[0])
-	tokenID = string(keys[1])
 	return
 }
 

--- a/x/nft/types/keys_test.go
+++ b/x/nft/types/keys_test.go
@@ -1,0 +1,28 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/crypto-org-chain/chain-main/v4/x/nft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitKeyDenomWithoutIBC(t *testing.T) {
+	keyDenom := []byte("testdenomid/testtokenid")
+
+	denomID, tokenID, err := types.SplitKeyDenom(keyDenom)
+
+	require.NoError(t, err)
+	require.Equal(t, "testdenomid", denomID)
+	require.Equal(t, "testtokenid", tokenID)
+}
+
+func TestSplitKeyDenomWithIBC(t *testing.T) {
+	keyDenom := []byte("ibc/testdenomid/testtokenid")
+
+	denomID, tokenID, err := types.SplitKeyDenom(keyDenom)
+
+	require.NoError(t, err)
+	require.Equal(t, "ibc/testdenomid", denomID)
+	require.Equal(t, "testtokenid", tokenID)
+}

--- a/x/nft/types/keys_test.go
+++ b/x/nft/types/keys_test.go
@@ -10,6 +10,7 @@ import (
 func TestSplitKeyDenomWithoutIBC(t *testing.T) {
 	keyDenom := []byte("testdenomid/testtokenid")
 
+	// nolint: govet
 	denomID, tokenID, err := types.SplitKeyDenom(keyDenom)
 
 	require.NoError(t, err)
@@ -20,6 +21,7 @@ func TestSplitKeyDenomWithoutIBC(t *testing.T) {
 func TestSplitKeyDenomWithIBC(t *testing.T) {
 	keyDenom := []byte("ibc/testdenomid/testtokenid")
 
+	// nolint: govet
 	denomID, tokenID, err := types.SplitKeyDenom(keyDenom)
 
 	require.NoError(t, err)


### PR DESCRIPTION
Solution: Fixed denomID and tokenID splitting logic when denom has `ibc`. Fixes #901.
