### PR TITLE
Problem: go 1.20.3 not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#927](https://github.com/crypto-org-chain/chain-main/pull/927) Integrate versiondb.
 - [#942](https://github.com/crypto-org-chain/chain-main/pull/942) Update cosmos-sdk to `v0.46.12` to support `iavl-lazy-loading`.
-- [#]() Update nixpkgs to release-22.11 and go version to 1.20.3.
+- [#946](https://github.com/crypto-org-chain/chain-main/pull/946) Update nixpkgs to release-22.11 and go version to 1.20.3.
 
 *February 20, 2023*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## UNRELEASED
+*April 27, 2023*
+
+## v4.2.4
 
 - [#927](https://github.com/crypto-org-chain/chain-main/pull/927) Integrate versiondb.
 - [#942](https://github.com/crypto-org-chain/chain-main/pull/942) Update cosmos-sdk to `v0.46.12` to support `iavl-lazy-loading`.
+- [#]() Update nixpkgs to release-22.11 and go version to 1.20.3.
 
 *February 20, 2023*
 

--- a/flake.lock
+++ b/flake.lock
@@ -56,16 +56,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677725835,
-        "narHash": "sha256-G/Y2u7MfUCYrHa15N/oE7R+lJmEC8FeIomkJDh8TEV0=",
+        "lastModified": 1682538316,
+        "narHash": "sha256-YuHgVsR7S9zxJWHo7lo2ugd+uDC4ESWg1hA4bEZQv3Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f16b8f48ea836282c81c915d6a16b0663a89d2d",
+        "rev": "15b75800dce80225b44f067c9012b09de37dfad2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
     flake-utils.url = "github:numtide/flake-utils";
     nix-bundle-exe = {
       url = "github:3noch/nix-bundle-exe";
@@ -72,6 +72,13 @@
         '';
         bundle-win-exe = drv: final.callPackage ./nix/bundle-win-exe.nix { cronosd = drv; };
         rocksdb = final.callPackage ./nix/rocksdb.nix { };
+        go_1_20 = prev.go_1_20.overrideAttrs (prev: rec {
+          version = "1.20.3";
+          src = final.fetchurl {
+            url = "https://go.dev/dl/go${version}.src.tar.gz";
+            hash = "sha256-5Ee0mM3lAhXE92GeUSSw/E4l+10W6kcnHEfyeOeqdjo=";
+          };
+        });
       } // (with final;
         let
           matrix = lib.cartesianProductOfSets {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,6 +13,13 @@ import sources.nixpkgs {
     })
     (import "${sources.gomod2nix}/overlay.nix")
     (pkgs: prev: {
+      go_1_20 = prev.go_1_20.overrideAttrs (prev: rec {
+        version = "1.20.3";
+        src = pkgs.fetchurl {
+          url = "https://go.dev/dl/go${version}.src.tar.gz";
+          hash = "sha256-5Ee0mM3lAhXE92GeUSSw/E4l+10W6kcnHEfyeOeqdjo=";
+        };
+      });
       go = pkgs.go_1_20;
       test-env = pkgs.callPackage ./testenv.nix { };
       lint-ci = pkgs.writeShellScriptBin "lint-ci" ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,15 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "release-22.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f16b8f48ea836282c81c915d6a16b0663a89d2d",
-        "sha256": "0p8i2cghw2b9la45gw02c4kaa7zd0kx3fydd3lmjcl0znfxkdxhv",
+        "rev": "15b75800dce80225b44f067c9012b09de37dfad2",
+        "sha256": "0xmza136qf0hssh2a4dq62w7w1xs6rdfxs314pqxqjvvqibf1qb2",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/4f16b8f48ea836282c81c915d6a16b0663a89d2d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/15b75800dce80225b44f067c9012b09de37dfad2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Solution:
- update nixpkgs to release-22.11
- manually update go src to 1.20.3
- prepare for v4.2.4 release

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

