### PR TITLE
chore(lint): skip running nixfmt in vendor folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bugfixes
 - [#1209](https://github.com/crypto-org-chain/chain-main/pull/1209) Patch comet bft (GHSA-hrhf-2vcr-ghch)
 - [#1252](https://github.com/crypto-org-chain/chain-main/pull/1252) fix: reject nft-transfer sends on non-nft port.
+- [#1260](https://github.com/crypto-org-chain/chain-main/pull/1260) chore(lint): skip running nixfmt in vendor folder
 
 *July 9, 2025*
 

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ lint:
 	@golangci-lint run
 	@go mod verify
 	@flake8 --show-source --count --statistics
-	@find . -name "*.nix" -type f | xargs nixfmt -c
+	@find . -name "*.nix" -type f -not -path "./vendor/*" | xargs nixfmt -c
 
 
 lint-fix:
@@ -208,7 +208,7 @@ lint-fix:
 	@golangci-lint run --fix
 	@go mod verify
 	@flake8 --show-source --count --statistics
-	@find . -name "*.nix" -type f | xargs nixfmt -c
+	@find . -name "*.nix" -type f -not -path "./vendor/*" | xargs nixfmt -c
 
 # a trick to make all the lint commands execute, return error when at least one fails.
 # golangci-lint is run in standalone job in ci


### PR DESCRIPTION
The linter should not run in the `vendor` folder due to those files are dependencies.

